### PR TITLE
Add URL prefix support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /usr/src/app
 RUN pip install --no-cache-dir flask flask_session hydrus-api gunicorn
 COPY . .
 ENV FLASK_APP server.py
-CMD SCRIPT_NAME=${HRT_URL_PREFIX} gunicorn -b :8243 server:app
+CMD SCRIPT_NAME=${HRT_URL_PREFIX} gunicorn --log-level=DEBUG -b :8243 server:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:alpine
 WORKDIR /usr/src/app
-RUN pip install --no-cache-dir flask flask_session hydrus-api
+RUN pip install --no-cache-dir flask flask_session hydrus-api gunicorn
 COPY . .
-CMD ["python","./server.py"]
+ENV FLASK_APP server.py
+CMD SCRIPT_NAME=${HRT_URL_PREFIX} gunicorn -b :8243 server:app

--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ docker build -t hydrus-remote-tagging .\Dockerfile
 
 Load the image into a container (Run the instance) and detach it from the CLI so that it runs in the background
 ```
-docker run -d -p ${PORT}:8243 -e HRT_SECRET_KEY=<yoursecretkey> hydrus-remote-tagging
+docker run -d -p ${PORT}:8243 -e HRT_SECRET_KEY=${SECRET} -e HRT_URL_PREFIX=${PREFIX} hydrus-remote-tagging
 ```
 
-Replace `${PORT}` with your desired available port (eg. port `80` or `8080`), and `<yoursecretkey>` with your secret key for Python's Flask.
-The instance should then be accessible at `http://localhost:${PORT}`
+Replace 
+  * `${PORT}` with your desired available port (eg. port `80` or `8080`)
+  * `${SECRET}` with your secret key
+  * `${PREFIX}` with the desired URL prefix (optional, lead with `/` when used or omit the `-e ...`)
+for Python's Flask.
+
+The instance should then be accessible at `http://localhost:${PORT}${PREFIX}` (eg. http://localhost:80/myapp)
 
 Omit the `-d` to make it run in the CLI.
+
+If you run Flask with URL prefix, be sure to NOT strip the prefix in your reverse proxy (if you use one). Flask expects to handle the full URL, read [this](https://dlukes.github.io/flask-wsgi-url-prefix.html) for further info.
 
 ## Pages:
 ### Main

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,10 @@
 <head>
     <meta charset="utf-8">
     <title>Hydrus Remote Tagging</title>
-    <link rel="stylesheet" href="/static/bootstrap.min.css">
-    <script src="/static/jquery-3.3.1.min.js"></script>
-    <script src="/static/bootstrap.min.js"></script>
-    <script src="/static/index.js" defer></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
+    <script src="{{ url_for('static', filename='jquery-3.3.1.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='bootstrap.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='index.js') }}" defer></script>
 </head>
 
 <body style="background: #19191b">
@@ -19,7 +19,7 @@
     {% endif %}
 
     <nav class="navbar navbar-expand-md navbar-dark bg-dark mb-3">
-        <a class="nav-link" href="/" style="font-size: 1.5em; font-weight: 600; color: white;">Hydrus Remote Tagging</a>
+        <a class="nav-link" href="{{ url_for('index') }}" style="font-size: 1.5em; font-weight: 600; color: white;">Hydrus Remote Tagging</a>
         <button type="button" class="btn btn-primary ms-auto m-2" data-bs-toggle="modal"
             data-bs-target="#tagPresentationModal">Settings</button>
     </nav>

--- a/templates/results.html
+++ b/templates/results.html
@@ -4,16 +4,16 @@
 <head>
     <meta charset="utf-8">
     <title>Tag Search Results</title>
-    <link rel="stylesheet" href="/static/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
 
 </head>
 
 <body style="background: #19191b">
     <nav class="navbar navbar-expand-md navbar-dark bg-dark mb-3">
-        <a class="nav-link" href="/" style="font-size: 1.5em; font-weight: 600; color: white;">Hydrus Remote Tagging</a>
+        <a class="nav-link" href="{{ url_for('index') }}" style="font-size: 1.5em; font-weight: 600; color: white;">Hydrus Remote Tagging</a>
     </nav>
     {% if ids %}
-    <form action="show-file/1" method="POST" class="mx-auto" style="display: flex; flex-direction: column;">
+    <form action="{{ url_for('ads', id=1) }}" method="POST" class="mx-auto" style="display: flex; flex-direction: column;">
         <h1 class="text-light mx-auto" style="align-self: center;"> Found {{ ids }} images for {{ tags }}</h1>
         <div class="d-flex justify-content-center my-2 text-white">
             <label for="idaaa" class="col-form-label mx-3">Select local tag repository to commit to:</label><select id="idaaa"

--- a/templates/show-file.html
+++ b/templates/show-file.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Hydrus Remote Tagging</title>
-    <link rel="stylesheet" href="/static/custom.css">
-    <link rel="stylesheet" href="/static/bootstrap.min.css">
-    <script src="/static/jquery-3.3.1.min.js"></script>
-    <script src="/static/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='custom.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap.min.css') }}">
+    <script src="{{ url_for('static', filename='jquery-3.3.1.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='bootstrap.min.js') }}"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
     {% for url in next_images %}
@@ -73,7 +73,7 @@
                     <path d="M3.612 15.443c-.386.198-.824-.149-.746-.592l.83-4.73L.173 6.765c-.329-.314-.158-.888.283-.95l4.898-.696L7.538.792c.197-.39.73-.39.927 0l2.184 4.327 4.898.696c.441.062.612.636.282.95l-3.522 3.356.83 4.73c.078.443-.36.79-.746.592L8 13.187l-4.389 2.256z"/>
                   </svg>
             </button>
-            <a class="nav-link" href="/" style="font-size: 1.5em; font-weight: 600; color: white;">ψ Remote Tagging</a>
+            <a class="nav-link" href="{{ url_for('index') }}" style="font-size: 1.5em; font-weight: 600; color: white;">ψ Remote Tagging</a>
             <button type="button" class="btn btn-primary float-end ms-auto me-3 metadataSidebarToggle">
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16" data-darkreader-inline-fill="" style="--darkreader-inline-fill:currentColor;">
                     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path>
@@ -217,7 +217,7 @@
         const repos = {{ repos | tojson }};
         const apiVersion = {{ api_version }};
     </script>
-    <script src="/static/show-file.js"></script>
+    <script src="{{ url_for('static', filename='show-file.js') }}"></script>
 
 
 </body>

--- a/templates/static/show-file.js
+++ b/templates/static/show-file.js
@@ -1,4 +1,4 @@
-var current = location.href.split('/')[4].replace(/\?.*$/, ''),
+var current = location.href.split('/').at(-1).replace(/\?.*$/, ''),
     next = parseInt(current) + 1,
     prev = parseInt(current) - 1,
     MAXhandyTags = 50,


### PR DESCRIPTION
I wanted to run this under a URL prefix, which needed some cleanup of previously absolute paths, one little logic change and moving the docker container from flask dev server to gunicorn to support the `SCRIPT_NAME` environment variable.

Tested in my setup, works like a charm.